### PR TITLE
Remove check for PyMySQL from 00-setup

### DIFF
--- a/tests/setup/00-setup
+++ b/tests/setup/00-setup
@@ -30,13 +30,6 @@ function install_apt_packages() {
 }
 
 
-function check_python_packages() {
-  if pip3 list | grep -q PyMySQL; then
-    return 1
-  fi
-}
-
-
 function install_python_packages() {
   # Setup for the generic 010-configs amulet test
   # PyMySQL not in main < Vivid, pip it instead
@@ -58,6 +51,4 @@ if ! check_apt_packages; then
   install_apt_packages
 fi
 
-if ! check_python_packages; then
-  install_python_packages
-fi
+install_python_packages


### PR DESCRIPTION
pip doesn't actually do any network traffic if a module is already
installed, so there's actually no point in doing the check ourselves.
And it's currently broken (missing ! and runs afoul of pypa/pip#1093 on
trusty).
