### PR TITLE
perform configuration post deployment

### DIFF
--- a/tests/010-configs
+++ b/tests/010-configs
@@ -13,7 +13,6 @@ max_connections = 10
 d = amulet.Deployment(series='trusty')
 
 d.add('mysql')
-d.configure('mysql', {'max-connections': max_connections})
 d.expose('mysql')
 
 try:
@@ -24,6 +23,8 @@ except amulet.helpers.TimeoutError:
 except:
     raise
 
+d.configure('mysql', {'max-connections': max_connections})
+d.sentry.wait()
 
 # Allow connections from outside
 mysqlmaster = d.sentry['mysql'][0]

--- a/tests/010-configs
+++ b/tests/010-configs
@@ -8,7 +8,7 @@ except ImportError:
     import pymysql3
 
 
-max_connections = 10
+max_connections = 30
 
 d = amulet.Deployment(series='trusty')
 
@@ -20,8 +20,6 @@ try:
     d.sentry.wait()
 except amulet.helpers.TimeoutError:
     amulet.raise_status(amulet.SKIP, msg="Environment wasn't stood up in time")
-except:
-    raise
 
 d.configure('mysql', {'max-connections': max_connections})
 d.sentry.wait()
@@ -36,34 +34,19 @@ mysqlmaster.run(
 mysql_server = d.sentry['mysql'][0]
 mysql_password = mysql_server.file_contents('/var/lib/mysql/mysql.passwd')
 
-connections = []
-
 # As we are using root as test user, we need to test with max_conn + 1
-cnx_list = []
 try:
-    for cnx_idx in range(0, max_connections + 10):
-        cnx = pymysql.connect(
-            user='root',
-            password=mysql_password,
-            host=mysql_server.info['public-address'],
-            database='mysql')
-
-        cnx_list.append(cnx)
-except pymysql.err.OperationalError as err:
-    TOO_MANY_USER_CONNECTIONS = 1203
-    err_code = err.args[0]
-    if err_code == TOO_MANY_USER_CONNECTIONS and \
-            len(cnx_list) < max_connections + 1:
-        amulet.raise_status(
-            amulet.FAIL,
-            'MySQL is not allowing to connect {} times, just {} times.'.format(
-                max_connections, len(cnx_list)))
-
+    cnx = pymysql.connect(
+        user='root',
+        password=mysql_password,
+        host=mysql_server.info['public-address'],
+        database='mysql')
+except:
+    amulet.raise_status(amulet.FAIL, msg='Unable to connect to MySQL')
 else:
-    amulet.raise_status(amulet.FAIL,
-                        'Max connection reached, and still able to connect.')
-
-for cnx in cnx_list:
     cnx.close()
 
-d.configure('mysql', {'max-connections': -1})
+cnf = mysql_server.file_contents('/etc/mysql/my.cnf')
+
+if 'max_connections = 30' not in cnf.split('\n'):
+    amulet.raise_status(amulet.FAIL, msg='Not writing configuration file properly')

--- a/tests/setup/00-setup
+++ b/tests/setup/00-setup
@@ -1,17 +1,6 @@
 #!/bin/bash -ex
 
-deps=(amulet
-      distro-info-data
-      python-cinderclient
-      python-distro-info
-      python-glanceclient
-      python-heatclient
-      python-keystoneclient
-      python-neutronclient
-      python-novaclient
-      python-pika
-      python-swiftclient
-      python3-pip)
+deps=(amulet distro-info-data python3-pip)
 
 
 function check_apt_packages() {

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,4 +1,3 @@
-# tests: "0([0-9]+)-((setup|configs)|basic-(precise|trusty)-(icehouse|juno|kilo))"
-tests: "0*"
 setup:
   - "tests/setup/00-setup"
+reset: false


### PR DESCRIPTION
this allows for non-reset tests to still be exercised.
