### PR TITLE
Use conf.d directory instead of changing my.cnf

### DIFF
--- a/hooks/config-changed
+++ b/hooks/config-changed
@@ -214,149 +214,18 @@ template="""
 #
 #
 ######################################
-#
-# The MySQL database server configuration file.
-#
-# You can copy this to one of:
-# - "/etc/mysql/my.cnf" to set global options,
-# - "~/.my.cnf" to set user-specific options.
-#
-# One can use all long options that the program supports.
-# Run program with --help to get a list of available options and with
-# --print-defaults to see which it would actually understand and use.
-#
-# For explanations see
-# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
-
-# This will be passed to all mysql clients
-# It has been reported that passwords should be enclosed with ticks/quotes
-# escpecially if they contain "#" chars...
-# Remember to edit /etc/mysql/debian.cnf when changing the socket location.
-[client]
-port		= 3306
-socket		= /var/run/mysqld/mysqld.sock
-
-# Here is entries for some specific programs
-# The following values assume you have at least 32M ram
-
-# This was formally known as [safe_mysqld]. Both versions are currently parsed.
-[mysqld_safe]
-socket		= /var/run/mysqld/mysqld.sock
-nice		= 0
-
 [mysqld]
-#
-# * Basic Settings
-#
-
-#
-# * IMPORTANT
-#   If you make changes to these settings and your system uses apparmor, you may
-#   also need to also adjust /etc/apparmor.d/usr.sbin.mysqld.
-#
-
-user		= mysql
-socket		= /var/run/mysqld/mysqld.sock
-port		= 3306
-basedir		= /usr
-datadir		= /var/lib/mysql
-tmpdir		= /tmp
-skip-external-locking
-#
-# Instead of skip-networking the default is now to listen only on
-# localhost which is more compatible and is not less secure.
 bind-address		= %(bind-address)s
-#
-# * Fine Tuning
-#
 key_buffer_size		= %(key-buffer)s
-max_allowed_packet	= 16M
-# This replaces the startup script and checks MyISAM tables if needed
-# the first time they are touched
-myisam-recover         = BACKUP
 %(max-connections)s
 %(wait-timeout)s
-#table_cache            = 64
-#thread_concurrency     = 10
-#
-# * Query Cache Configuration
-#
-query_cache_limit = 1M
 query_cache_size = %(query-cache-size)s
 query_cache_type = %(query-cache-type)s
-#
-# * Logging and Replication
-#
-# Both location gets rotated by the cronjob.
-# Be aware that this log type is a performance killer.
-# As of 5.1 you can enable the log at runtime!
-#general_log_file        = /var/log/mysql/mysql.log
-#general_log             = 1
 
-log_error                = /var/log/mysql/error.log
-
-# Here you can see queries with especially long duration
-#log_slow_queries	= /var/log/mysql/mysql-slow.log
-#long_query_time = 2
-#log-queries-not-using-indexes
-#
-# The following can be used as easy to replay backup logs or for replication.
-# note: if you are setting up a replication slave, see README.Debian about
-#       other settings you may need to change.
-#server-id		= 1
-#log_bin			= /var/log/mysql/mysql-bin.log
-expire_logs_days	= 10
-max_binlog_size         = 100M
-#binlog_do_db		= include_database_name
-#binlog_ignore_db	= include_database_name
-#
-# * InnoDB
-#
-# InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
-# We also set innodb_file_per_table to avoid having ibdata1 fill the disk.
-# Read the manual for more InnoDB related options. There are many!
-#
-innodb_file_per_table
 innodb_buffer_pool_size = %(innodb-buffer-pool-size)s
 innodb_flush_log_at_trx_commit = %(innodb-flush-log-at-trx-commit)s
 sync_binlog = %(sync-binlog)s
 default_storage_engine = %(default-storage-engine)s
-skip-name-resolve
-# * Security Features
-#
-# Read the manual, too, if you want chroot!
-# chroot = /var/lib/mysql/
-#
-# For generating SSL certificates I recommend the OpenSSL GUI "tinyca".
-#
-# ssl-ca=/etc/mysql/cacert.pem
-# ssl-cert=/etc/mysql/server-cert.pem
-# ssl-key=/etc/mysql/server-key.pem
-
-#
-# * Encoding
-#
-# Set all the tables to utf8 by default.
-collation-server = utf8_general_ci
-init-connect='SET NAMES utf8'
-character-set-server = utf8
-
-[mysqldump]
-quick
-quote-names
-max_allowed_packet	= 16M
-
-[mysql]
-#no-auto-rehash	# faster start of mysql but no tab completition
-
-[isamchk]
-key_buffer_size		= 16M
-
-#
-# * IMPORTANT: Additional settings that can override those from this file!
-#   The files must end with '.cnf', otherwise they'll be ignored.
-#
-!includedir /etc/mysql/conf.d/
 """
 
 i_am_a_slave = os.path.isfile('/var/lib/juju/i.am.a.slave')
@@ -378,8 +247,17 @@ binlog_format = %s
 
 mycnf=template % configs
 
-targets = {'/etc/mysql/conf.d/binlog.cnf': binlog_cnf,
-           '/etc/mysql/my.cnf': mycnf,
+target_prefix='/etc/mysql/conf.d'
+if os.path.exists('/etc/mysql/mysql.conf.d'):
+    # configuration files in this directory have precedence
+    target_prefix='/etc/mysql/mysql.conf.d'
+
+# Naming of config files is crucial. The values read from the last file loaded
+# will take precedence. On Xenial and newer there is a complete MySQL
+# configuration file in /etc/mysql/mysql.conf.d/mysqld.cnf. Naming our file
+# 'mysqld_settings_charm.cnf' will make it load after that.
+targets = {os.path.join(target_prefix, 'binlog.cnf'): binlog_cnf,
+           os.path.join(target_prefix, 'mysqld_settings_charm.cnf'): mycnf,
            }
 
 need_restart = False
@@ -404,6 +282,7 @@ for target,content in targets.iteritems():
                     need_restart = True
         else:
             need_restart = True
+        os.chmod(t.name, 0o644)
         os.rename(t.name, target)
 
 if need_restart:


### PR DESCRIPTION
Remove default values from template, use default values
maintained by distribution instead.

Include only values we want to override in the charm
provided config file.

Tested by hand on Ubuntu precise, trusty and xenial.

Fixes #9