### PR TITLE
add bionic; remove artful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+.coverage
 .project
+*.pyc
+__pycache__
 .pydevproject
+.venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
  - UNIT_TEST=1
  - AMULET_TEST=gate-basic-trusty
  - AMULET_TEST=gate-basic-xenial
- - AMULET_TEST=gate-basic-artful
+ - AMULET_TEST=gate-basic-bionic
 script:
  - if [ ! -z ${UNIT_TEST} ]; then make lint; fi
  - if [ ! -z ${UNIT_TEST} ]; then make test; fi

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: mysql
 summary: MySQL is a fast, stable and true multi-user, multi-threaded SQL database
-maintainer: Marco Ceppi <marco@ceppi.net>
+maintainer: MySQL Charmers <charmers@lists.launchpad.net>
 description: |
   MySQL is a fast, stable and true multi-user, multi-threaded SQL database
   server. SQL (Structured Query Language) is the most popular database query
@@ -10,8 +10,8 @@ tags:
     - databases
     - openstack
 series:
-  - artful
   - xenial
+  - bionic
   - trusty
 provides:
   db:

--- a/tests/gate-basic-bionic
+++ b/tests/gate-basic-bionic
@@ -17,5 +17,5 @@
 from basic_deployment import MySQLBasicDeployment
 
 if __name__ == '__main__':
-    deployment = MySQLBasicDeployment(series='artful')
+    deployment = MySQLBasicDeployment(series='bionic')
     deployment.run_tests()


### PR DESCRIPTION
After the disasters that were #27, #28, and #29, i'm resubmitting this.  I split the travis move to xenial out into #30 and will handle syncing CH in a future PR.  This does the following:

- add bionic as a supported series, but keep xenial as the default for now
- remove artful as a supported series (EOL Jun 2018)
- update maintainers field